### PR TITLE
Use latest opencv release to avoid missing Mac lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 wpi.maven.useDevelopment = true
 wpi.wpilibVersion = '2021.+'
+wpi.opencvVersion = '3.4.7-5' // Remove when officially released
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
This makes the simulator work on the Mac without any special dll.zip files on the Mac.
