### PR TITLE
Update vendor libs to latest official versions.

### DIFF
--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,81 +1,69 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.18.3",
+    "version": "5.19.4",
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
-        "http://devsite.ctr-electronics.com/maven/release/"
+        "https://devsite.ctr-electronics.com/maven/release/"
     ],
-    "jsonUrl": "http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "jsonUrl": "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
     "javaDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.18.3"
+            "version": "5.19.4"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.18.3"
+            "version": "5.19.4"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
-                "linuxathena",
-                "windowsx86-64",
-                "linuxx86-64"
+                "linuxathena"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "diagnostics",
-            "version": "5.18.3",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
-                "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "canutils",
-            "version": "5.18.3",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "platform-stub",
-            "version": "5.18.3",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
-            ]
-        },
-        {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "core",
-            "version": "5.18.3",
-            "isJar": false,
-            "skipInvalidPlatforms": true,
-            "validPlatforms": [
-                "linuxathena",
-                "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         }
     ],
@@ -83,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -91,13 +79,14 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -105,27 +94,40 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
-                "linuxathena",
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixDiagnostics",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -133,39 +135,42 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCanutils",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
-            "artifactId": "platform-stub",
-            "version": "5.18.3",
+            "artifactId": "platform-sim",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixPlatform",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.18.3",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCore",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -173,7 +178,36 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
             ]
         }
     ]

--- a/vendordeps/REVRobotics.json
+++ b/vendordeps/REVRobotics.json
@@ -8,14 +8,15 @@
                 "linuxaarch64bionic",
                 "linuxx86-64",
                 "linuxathena",
-                "linuxraspbian"
+                "linuxraspbian",
+                "osxx86-64"
             ],
             "groupId": "com.revrobotics.frc",
             "headerClassifier": "headers",
             "libName": "SparkMax",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
-            "version": "1.5.2"
+            "version": "1.5.4"
         },
         {
             "artifactId": "SparkMax-driver",
@@ -25,14 +26,15 @@
                 "linuxaarch64bionic",
                 "linuxx86-64",
                 "linuxathena",
-                "linuxraspbian"
+                "linuxraspbian",
+                "osxx86-64"
             ],
             "groupId": "com.revrobotics.frc",
             "headerClassifier": "headers",
             "libName": "SparkMaxDriver",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
-            "version": "1.5.2"
+            "version": "1.5.4"
         }
     ],
     "fileName": "REVRobotics.json",
@@ -40,7 +42,7 @@
         {
             "artifactId": "SparkMax-java",
             "groupId": "com.revrobotics.frc",
-            "version": "1.5.2"
+            "version": "1.5.4"
         }
     ],
     "jniDependencies": [
@@ -55,9 +57,10 @@
                 "linuxaarch64bionic",
                 "linuxx86-64",
                 "linuxathena",
-                "linuxraspbian"
+                "linuxraspbian",
+                "osxx86-64"
             ],
-            "version": "1.5.2"
+            "version": "1.5.4"
         }
     ],
     "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
@@ -66,5 +69,5 @@
     ],
     "name": "REVRobotics",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "version": "1.5.2"
+    "version": "1.5.4"
 }


### PR DESCRIPTION
This fixes the SparkMax library issue on Macs.